### PR TITLE
fix: Correct package manager in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
-the og group 
+# OG Tech Minds Community Platform
+
+This is the official web application for the OG Tech Minds community. This platform is designed to connect members, facilitate collaboration, and showcase the group's projects and achievements.
+
+## 🚀 Key Features
+
+*   **Member Profiles:** Create and manage your own member profile.
+*   **Project Showcase:** Display your projects and see what other members are working on.
+*   **Events & Announcements:** Stay up-to-date with the latest community events and announcements.
+*   **Collaboration Hub:** Connect with other members and collaborate on projects.
+*   **Alumni Network:** Keep in touch with past members and see what they're up to.
+*   **Certificate Verification:** Verify the authenticity of certificates issued by OG Tech Minds.
+
+## 💻 Tech Stack
+
+This project is built with the following technologies:
+
+*   **Frontend:** React, Vite, TypeScript, Tailwind CSS, Shadcn/UI
+*   **Routing:** React Router
+*   **State Management:** React Query
+*   **Forms:** React Hook Form
+*   **Deployment:** Vercel
+
+## 🛠️ Getting Started
+
+To get a local copy up and running, follow these simple steps.
+
+### Prerequisites
+
+*   Node.js (v18 or higher)
+*   npm
+
+### Installation
+
+1.  **Fork the repository**
+2.  **Clone the repository:**
+    ```sh
+    git clone https://github.com/YOUR_USERNAME/og-community-platform.git
+    ```
+3.  **Navigate to the project directory:**
+    ```sh
+    cd og-community-platform
+    ```
+4.  **Install dependencies:**
+    ```sh
+    npm install
+    ```
+5.  **Start the development server:**
+    ```sh
+    npm run dev
+    ```
+
+The application will be available at `http://localhost:5173`.
+
+## 🤝 Contributing
+
+Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+Please refer to the `CONTRIBUTING.md` file for our contribution guidelines.
+
+## 📄 License
+
+This project is licensed under the MIT License. See the `LICENSE` file for details.


### PR DESCRIPTION
This commit corrects the README.md file to use `npm` instead of `bun` for installation and development. It also reverts the changes to `bun.lockb` that were incorrectly introduced.